### PR TITLE
Remove extra bundler require

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -2,7 +2,6 @@ require 'rubygems'
 require 'bundler'
 require 'sinatra'
 require 'sinatra/reloader' if development?
-require 'bundler'
 require 'sinatra/json'
 require 'sinatra/cookies'
 require 'sinatra/flash'


### PR DESCRIPTION
Simply removes an extra `require 'bundler'`